### PR TITLE
issue#05 tsconfig, viteconfig & 절대경로 설정

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"@eslint/js": "^9.17.0",
 		"@testing-library/jest-dom": "^6.6.3",
 		"@trivago/prettier-plugin-sort-imports": "^5.2.1",
+		"@types/node": "^22.10.7",
 		"@types/react": "^19.0.7",
 		"@types/react-dom": "^19.0.3",
 		"@typescript-eslint/eslint-plugin": "^8.20.0",
@@ -41,6 +42,7 @@
 		"prettier": "^3.4.2",
 		"typescript": "~5.6.2",
 		"typescript-eslint": "^8.18.2",
-		"vite": "^6.0.5"
+		"vite": "^6.0.5",
+		"vite-tsconfig-paths": "^5.1.4"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^5.2.1
         version: 5.2.1(prettier@3.4.2)
+      '@types/node':
+        specifier: ^22.10.7
+        version: 22.10.7
       '@types/react':
         specifier: ^19.0.7
         version: 19.0.7
@@ -96,6 +99,9 @@ importers:
       vite:
         specifier: ^6.0.5
         version: 6.0.7(@types/node@22.10.7)
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.6.3)(vite@6.0.7(@types/node@22.10.7))
 
 packages:
 
@@ -1434,6 +1440,9 @@ packages:
     resolution: {integrity: sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig==}
     engines: {node: '>=18'}
 
+  globrex@0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
@@ -2359,6 +2368,16 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  tsconfck@3.1.4:
+    resolution: {integrity: sha512-kdqWFGVJqe+KGYvlSO9NIaWn9jT1Ny4oKVzAJsKii5eoE9snzTJzL4+MMVOMn+fikWGFmKEylcXL710V/kIPJQ==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   tslib@2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
 
@@ -2525,6 +2544,14 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vite-tsconfig-paths@5.1.4:
+    resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
 
   vite@6.0.7:
     resolution: {integrity: sha512-RDt8r/7qx9940f8FcOIAH9PTViRrghKaK2K1jY3RaAURrEUbm9Du1mJ72G+jlhtG3WwodnfzY8ORQZbBavZEAQ==}
@@ -4093,6 +4120,8 @@ snapshots:
 
   globals@15.14.0: {}
 
+  globrex@0.1.2: {}
+
   graphemer@1.4.0: {}
 
   graphql@16.10.0: {}
@@ -5307,6 +5336,10 @@ snapshots:
     dependencies:
       typescript: 5.6.3
 
+  tsconfck@3.1.4(typescript@5.6.3):
+    optionalDependencies:
+      typescript: 5.6.3
+
   tslib@2.4.0: {}
 
   tslib@2.8.1: {}
@@ -5488,6 +5521,17 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
+
+  vite-tsconfig-paths@5.1.4(typescript@5.6.3)(vite@6.0.7(@types/node@22.10.7)):
+    dependencies:
+      debug: 4.4.0
+      globrex: 0.1.2
+      tsconfck: 3.1.4(typescript@5.6.3)
+    optionalDependencies:
+      vite: 6.0.7(@types/node@22.10.7)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   vite@6.0.7(@types/node@22.10.7):
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,15 @@
-import { Routes } from './app/routes';
-import { ReactQueryClientProvider } from './shared/lib/query-client';
+import { Routes } from '@app/routes';
 import { ChakraProvider } from '@chakra-ui/react';
+import { ReactQueryClientProvider } from '@shared/lib';
 
 const App = () => {
-  return (
-    <ReactQueryClientProvider>
-      <ChakraProvider>
-        <Routes />
-      </ChakraProvider>
-    </ReactQueryClientProvider>
-  );
+	return (
+		<ReactQueryClientProvider>
+			<ChakraProvider>
+				<Routes />
+			</ChakraProvider>
+		</ReactQueryClientProvider>
+	);
 };
 
 export default App;

--- a/src/app/routes/router.tsx
+++ b/src/app/routes/router.tsx
@@ -1,14 +1,14 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 
-import { MainPage } from '../../pages/main';
+import { MainPage } from '@pages/main';
 
 const router = createBrowserRouter([
-  {
-    path: '/',
-    element: <MainPage />,
-  },
+	{
+		path: '/',
+		element: <MainPage />,
+	},
 ]);
 
 export const Routes = () => {
-  return <RouterProvider router={router} />;
+	return <RouterProvider router={router} />;
 };

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -20,7 +20,16 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+
+    /* Path aliases */
+    "baseUrl": "./",
+    "paths": {
+      "@app/*": ["src/app/*"],
+      "@pages/*": ["src/pages/*"],
+      "@shared/*": ["src/shared/*"],
+      "@widgets/*": ["src/widgets/*"]
+    }
   },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "files": [],
   "references": [
-    { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.app.json" }, // 웹 애플리케이션용 설정
+    { "path": "./tsconfig.node.json" } // Node.js 환경용 설정
   ]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -3,11 +3,11 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "target": "ES2022",
     "lib": ["ES2023"],
-    "module": "ESNext",
+    "module": "ESNext", //프로젝트가 최신 Node.js 환경을 대상으로 하기에 ESNext를 유지함.
     "skipLibCheck": true,
 
     /* Bundler mode */
-    "moduleResolution": "bundler",
+    "moduleResolution": "bundler", //브라우저에서도 동작해야함으로 bunler 해석 방식을 유지함.
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,16 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import path from "path"; // Node.js의 path 모듈
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  resolve: {
+    alias: {
+      "@app": path.resolve(__dirname, "src/app"),
+      "@pages": path.resolve(__dirname, "src/pages"),
+      "@shared": path.resolve(__dirname, "src/shared"),
+      "@widgets": path.resolve(__dirname, "src/widgets"),
+    },
+  },
+});


### PR DESCRIPTION
## 📝 상세 내용
# tsconfig.json (수정하지 않음)
![{0CA43BCE-AE19-40A4-94BA-DC7D4065BA76}](https://github.com/user-attachments/assets/aa1492b1-99d0-4c6e-94f2-a57d76c24a25)

tsconfig.json 파일은 tsconfig.app.json와 tsconfig.node.json을 관리하기 위한 TS 설정의 루트 파일이므로 추가적인 수정은 필요하지 않다고 판단했다. (수정할꺼면 tsconfig.app.json, tsconfig.node.json을 하면 될 것이다..)
그래서 주석만 작성해 주었다.

“files” 속성은 **컴파일러가 처리할 파일을 명시적으로 지정**하는 데 사용된다고 한다. (테스트 용도, 다중 프로젝트에서)
이 속성을 사용하면 TypeScript가 특정 파일만 컴파일하도록 설정할 수 있는데 현재는 빈 배열과 함께 `references`로 컴파일할 파일을 지정하였다.

# tsconfig.node.json (수정하지 않음)
![{1BF1259E-C6FA-403C-BFFB-737F64DC3B87}](https://github.com/user-attachments/assets/d1b3362c-b992-4c67-ad36-3aefd8b16af8)

현재 브라우저 환경에 맞게 세팅되어 있다고 판단되어 추가로 수정하지 않았다.
만약 node.js 환경에 적합한 세팅을 한다고 가정하면, module을 commonJS로, moduleResolution을 node로 변경하면 될 것이다.

# tsconfig.app.json (절대경로 설정함)
![{689F2FC4-C4F0-4E6A-AB57-F8659E56CBAB}](https://github.com/user-attachments/assets/07261e8a-4fdd-404a-a0c7-93767e5b977e)


절대 경로로 파일을 import 하면 코드의 가독성을 더 높일 수 있을 것 같다고 합의되어 경로 설정을 해주었다.

# vite.configt.ts (절대경로 설정함)
![{15C76882-CAC7-4BC0-BCFD-C21F0EE35674}](https://github.com/user-attachments/assets/a8dc3ca4-7ef0-4569-b47e-d9bec693489c)


Vite에서도 동일한 경로 별칭(alias)을 설정해 줘야 번들러가 이를 인식할 수 있어 경로 설정을 해주었다.
이 과정에서 vite-tsconfig-paths를 설치해주었다.
**`vite-tsconfig-paths`**: TypeScript의 `paths` 설정을 Vite에서 자동으로 처리하기 위한 플러그인.


## #️⃣ 이슈 번호

- close #5 

## 💬 리뷰 요구사항
- 절대 경로가 잘 참조되는지 확인
- "pnpm add -D vite-tsconfig-paths" 로 필요한 모듈을 하나 설치했습니다.

## ⏰ 현재 버그
x

## 📷 스크린샷(선택)
x

## 🔗 참고 자료(선택)
https://shape-coding.tistory.com/entry/Vite-TypeScript-Vite-%ED%83%80%EC%9E%85%EC%8A%A4%ED%81%AC%EB%A6%BD%ED%8A%B8-%ED%99%98%EA%B2%BD%EC%97%90%EC%84%9C-%EC%A0%88%EB%8C%80-%EA%B2%BD%EB%A1%9C-%EC%84%A4%EC%A0%95%ED%95%98%EA%B8%B0
