### PR TITLE
issue#21 post 작성 및 수정 modal 구현

### DIFF
--- a/src/pages/post-edit/data/index.ts
+++ b/src/pages/post-edit/data/index.ts
@@ -1,0 +1,1 @@
+export { POST_DETAIL_DUMMY_DATA } from './post-detail';

--- a/src/pages/post-edit/data/post-detail.ts
+++ b/src/pages/post-edit/data/post-detail.ts
@@ -1,0 +1,12 @@
+export const POST_DETAIL_DUMMY_DATA = {
+  id: 2,
+  title: 'JavaScript ES6의 신기능',
+  content: 'ES6에서 추가된 새로운 기능들을 배워봅니다.',
+  thumbnail: 'https://picsum.photos/320/167?random=2',
+  summary: 'ES6의 주요 기능과 문법 개선 사항을 소개합니다.',
+  likeCount: 25,
+  commentCount: 8,
+  createdAt: '2025-01-24T15:30:00.000Z',
+  updatedAt: '2025-01-24T16:00:00.000Z',
+  author: '고영희',
+};

--- a/src/pages/post-edit/ui/PostEditPage.tsx
+++ b/src/pages/post-edit/ui/PostEditPage.tsx
@@ -1,3 +1,40 @@
+import { Button, useDisclosure } from '@chakra-ui/react';
+
+import { useGetMockData } from '@shared/hooks';
+
+import { PostModal } from '@widgets/modals';
+import { LoadingView } from '@widgets/view';
+
+import { POST_DETAIL_DUMMY_DATA } from '../data';
+
 export const PostEditPage = () => {
-  return <div>PostEditPage</div>;
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  const { data, isPending, isError } = useGetMockData(POST_DETAIL_DUMMY_DATA);
+
+  //TODO: 게시글 수정하기 버튼 클릭 시 Modal 열기
+  const onClick = () => {
+    onOpen();
+  };
+
+  //TODO: 게시글 data 불러오는 중에 에러 발생 시 custom Toast 메시지 띄우기
+  if (isError) return <div>오류가 발생했습니다.</div>;
+
+  //TODO: 게시글 data 불러올 떄 Skeleton으로 변경
+  if (isPending) return <LoadingView />;
+
+  return (
+    <div>
+      <Button onClick={onClick}>수정하기</Button>
+      <PostModal
+        title={data.title}
+        isOpen={isOpen}
+        onClose={onClose}
+        buttonTitle='수정하기'
+        postType='edit'
+        imageUrl={data.thumbnail}
+        postContent={data.content}
+      />
+    </div>
+  );
 };

--- a/src/pages/post-write/ui/PostWritePage.tsx
+++ b/src/pages/post-write/ui/PostWritePage.tsx
@@ -1,3 +1,25 @@
+import { useDisclosure, Button } from '@chakra-ui/react';
+
+import { PostModal } from '@widgets/modals';
+
 export const PostWritePage = () => {
-  return <div>PostWritePage</div>;
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  //TODO: 작성완료 버튼 클릭 시 Modal 열기
+  const onClick = () => {
+    onOpen();
+  };
+
+  return (
+    <div>
+      <Button onClick={onClick}>작성완료</Button>
+      <PostModal
+        title='백준 1004번 풀이'
+        isOpen={isOpen}
+        onClose={onClose}
+        buttonTitle='출간하기'
+        postType='create'
+      />
+    </div>
+  );
 };

--- a/src/widgets/modals/PostModal.tsx
+++ b/src/widgets/modals/PostModal.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useRef, useState } from 'react';
+
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalCloseButton,
+  ModalBody,
+  ModalFooter,
+  Button,
+  Flex,
+  Text,
+  HStack,
+  Textarea,
+  VStack,
+  Image,
+  Input,
+} from '@chakra-ui/react';
+
+import { ImagePlus } from 'lucide-react';
+
+type PostModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  buttonTitle: string;
+  postType: 'create' | 'edit';
+  imageUrl?: string;
+  postContent?: string;
+};
+
+export const PostModal = ({
+  isOpen,
+  onClose,
+  title,
+  buttonTitle,
+  imageUrl,
+  postType,
+  postContent,
+}: PostModalProps) => {
+  const [inputCount, setInputCount] = useState<number>(0);
+  const [imgFile, setImgFile] = useState<File>();
+  const [imgPath, setImgPath] = useState('');
+  const [contents, setContents] = useState<string>(postContent || '');
+  const [showControls, setShowControls] = useState<boolean>(false);
+
+  const imgRef = useRef<HTMLInputElement | null>(null);
+
+  const MAX_IMAGE_SIZE_BYTES = 1024 * 1024 * 2;
+
+  const onCountText = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setInputCount(e.target.value.length);
+    setContents(e.target.value);
+  };
+
+  const onClick = () => {
+    imgRef.current?.click();
+  };
+
+  const onFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    if (file.size > MAX_IMAGE_SIZE_BYTES) {
+      alert('이미지 사이즈는 2MB를 넘을 수 없습니다.');
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      setImgFile(file);
+      setImgPath(reader.result as string);
+    };
+    reader.readAsDataURL(file);
+    setShowControls(true);
+  };
+
+  const onFileDelete = () => {
+    setImgFile(undefined);
+    setImgPath('');
+    setShowControls(false);
+  };
+
+  useEffect(() => {
+    if (postType === 'edit') {
+      setImgPath(imageUrl || '');
+      setContents(postContent || '');
+      setShowControls(!!imageUrl);
+    }
+  }, [imageUrl, postType, postContent]);
+
+  return (
+    <Modal size='sm' isOpen={isOpen} onClose={onClose} isCentered>
+      <ModalOverlay bg='blackAlpha.300' backdropFilter='blur(3px)' />
+      <ModalContent w='100%'>
+        <ModalHeader mt={5} textAlign='left' ml='3'>
+          포스트 미리보기
+        </ModalHeader>
+        <ModalCloseButton />
+
+        <ModalBody textAlign='center' justifyContent='center' alignItems='center'>
+          {showControls && (
+            <Flex w='325px' pb={1} justifyContent='flex-end' gap={2}>
+              <Text
+                as='button'
+                fontSize='sm'
+                fontWeight='700'
+                color='customGray.400'
+                textDecor='underline'
+                onClick={onFileDelete}
+              >
+                썸네일 제거
+              </Text>
+            </Flex>
+          )}
+          <VStack flexDir='column' textAlign='center' spacing={3} px={3}>
+            <Flex bgColor='#E9ECEE' justify='center' w='full' h='166px' flexDir='column'>
+              <VStack spacing={2}>
+                {imgFile || imgPath ? (
+                  <Image src={imgPath} alt='thumbnail' maxW='312px' maxH='166px' />
+                ) : (
+                  <>
+                    <VStack spacing={2}>
+                      <ImagePlus strokeWidth={1} size={100} color='gray' />
+                    </VStack>
+                    <Button
+                      onClick={onClick}
+                      variant='outline'
+                      px={5}
+                      py='2px'
+                      fontSize='sm'
+                      borderColor='white'
+                      transition='all 0.2s ease-in-out'
+                      borderRadius='3px'
+                      _hover={{
+                        borderColor: 'custom.blue',
+                        backgroundColor: 'custom.blue',
+                        color: 'white',
+                        transition: 'all 0.2s ease-in-out',
+                      }}
+                    >
+                      썸네일 업로드
+                      <Input
+                        type='file'
+                        name='photo'
+                        display='none'
+                        accept='image/png, image/jpeg, image/jpg'
+                        ref={imgRef}
+                        onChange={onFileChange}
+                      />
+                    </Button>
+                  </>
+                )}
+              </VStack>
+            </Flex>
+            <Flex w='full' flexDir='column'>
+              <Flex w='full' py={3}>
+                <Text as='b' fontSize='xl'>
+                  {title}
+                </Text>
+              </Flex>
+              <Flex w='full' flexDir='column'>
+                <Textarea
+                  w='full'
+                  px={3}
+                  h='100px'
+                  maxLength={150}
+                  placeholder='나의 포스트를 짧게 소개해보아요.'
+                  fontSize='sm'
+                  onChange={onCountText}
+                  value={contents}
+                />
+                <Flex w='full' justify='flex-end' mt='2px'>
+                  <Text as='b' fontSize='sm' color='customGray.500'>
+                    {`${inputCount}/150`}
+                  </Text>
+                </Flex>
+              </Flex>
+            </Flex>
+          </VStack>
+        </ModalBody>
+
+        <ModalFooter w='full' flexDir='row' px={9} mb={3}>
+          <HStack spacing={2}>
+            <Button
+              variant='outline'
+              border='none'
+              _hover={{}}
+              w='full'
+              h='40px'
+              colorScheme='custom.blue'
+              onClick={onClose}
+            >
+              취소
+            </Button>
+            <Button
+              w='full'
+              h='40px'
+              px={5}
+              borderRadius='3px'
+              colorScheme='custom.blue'
+              _hover={{}}
+            >
+              {buttonTitle}
+            </Button>
+          </HStack>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/src/widgets/modals/index.ts
+++ b/src/widgets/modals/index.ts
@@ -1,1 +1,2 @@
 export { HeaderModal } from './HeaderModal';
+export { PostModal } from './PostModal';

--- a/src/widgets/post-cards/PostCards.tsx
+++ b/src/widgets/post-cards/PostCards.tsx
@@ -28,8 +28,8 @@ export const PostCards = ({
 
   return (
     <Flex
-      w='300px'
-      h='380px'
+      w='290px'
+      h='400px'
       bg='white'
       flexDir='column'
       boxShadow='5px 5px 20px 0px rgba(0, 0, 0, 0.10)'

--- a/src/widgets/post-cards/SkeletonPostCards.tsx
+++ b/src/widgets/post-cards/SkeletonPostCards.tsx
@@ -11,8 +11,8 @@ import {
 export const SkeletonPostCards = () => {
   return (
     <Flex
-      w='300px'
-      h='380px'
+      w='290px'
+      h='400px'
       bg='white'
       flexDir='column'
       boxShadow='5px 5px 20px 0px rgba(0, 0, 0, 0.10)'


### PR DESCRIPTION
## 📝 상세 내용

게시글 작성과 게시글 수정 마지막 단계에서 나타나는 modal을 구현했습니다.

## #️⃣ 이슈 번호

- closes #21

## 💬 리뷰 요구사항
### 썸네일 이미지
기존 ui를 조금 수정해보았어요.
![image](https://github.com/user-attachments/assets/15cf5deb-29bb-4331-bc20-c7e57379d95d)
원래는 velog 처럼 썸네일 이미지 위에 '재업로드'와 '제거' 버튼이 2개 위치해 있는데,
기존 사진을 '제거' 한다면 '재업로드' 버튼이 의미가 있을까? 라는 생각이 들었습니다.

![image](https://github.com/user-attachments/assets/2f98f617-312d-4cb0-8be3-b3a4fb856664)
'제거'를 하게되면 이 화면으로 돌아오기 때문입니다.

그래서 구현하면서 '썸네일 제거' 버튼 하나만 사용하기로 하였습니다.
<img width="428" alt="image" src="https://github.com/user-attachments/assets/c295bcea-3a04-4d37-ac51-8300436743fa" />

제거를 누르면 다시 썸네일 사진을 선택할 수 있습니다.

<img width="406" alt="image" src="https://github.com/user-attachments/assets/137b676a-e55b-443b-8f09-98aa49582d89" />

저는 클라이언트단에서 썸네일 제거하고 다시 서버로 썸네일 사진을 업로드할 수 있기 때문에 크게 상관은 없다고 생각해서 이렇게 변경하였는데, 이럴경우에는 사용자 입장에서는 '재업로드'로 한번에 사진을 변경할 수 있지만, 제거 → 업로드로 두번 거쳐가야해서 조금 번거로울 수도 있겠다는 생각이 드네요.

어떻게 생각하시나요?

## ⏰ 현재 버그
절대 재업로드 구현 중에 버그가 생겨서가 아니라... ㅎㅎ

## 📷 스크린샷(선택)
<img width="1129" alt="image" src="https://github.com/user-attachments/assets/d633c388-1141-482e-afc9-06ef82a6f03f" />


## 🔗 참고 자료(선택)

