### PR TITLE
issue#23 커스텀 Toast 구현

### DIFF
--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './mock';
+export * from './toast';

--- a/src/shared/hooks/toast/index.ts
+++ b/src/shared/hooks/toast/index.ts
@@ -1,0 +1,1 @@
+export { useCustomToast } from './useCustomToast';

--- a/src/shared/hooks/toast/useCustomToast.tsx
+++ b/src/shared/hooks/toast/useCustomToast.tsx
@@ -1,0 +1,38 @@
+import { useToast } from '@chakra-ui/react';
+
+type UseCustomToastProps = {
+  toastStatus: 'success' | 'error' | 'warning' | 'info';
+  toastTitle: string;
+  toastDescription: string;
+  duration?: number;
+};
+
+export const useCustomToast = () => {
+  const toast = useToast();
+
+  /**
+   * 아래 customToast는 사용예시입니다.
+   * customToast({
+      toastStatus: 'success', -> 'success', 'error', 'warning', 'info' 중 선택
+      toastTitle: '성공!', -> Toast의 제목
+      toastDescription: '작업이 성공적으로 완료되었습니다.', -> Toast의 내용
+    });
+   * 
+   */
+  const customToast = ({
+    toastStatus,
+    toastTitle,
+    toastDescription,
+    duration = 5000,
+  }: UseCustomToastProps) => {
+    toast({
+      title: toastTitle,
+      description: toastDescription,
+      status: toastStatus,
+      duration,
+      variant: 'subtle',
+    });
+  };
+
+  return customToast;
+};

--- a/src/shared/providers/application-provider.tsx
+++ b/src/shared/providers/application-provider.tsx
@@ -9,7 +9,12 @@ import { QueryClientProvider } from '@tanstack/react-query';
 export const ApplicationProvider = ({ children }: { children: ReactNode }) => {
   return (
     <QueryClientProvider client={queryClient}>
-      <ChakraProvider theme={globalStyle}>{children}</ChakraProvider>
+      <ChakraProvider
+        theme={globalStyle}
+        toastOptions={{ defaultOptions: { position: 'bottom-left' } }}
+      >
+        {children}
+      </ChakraProvider>
     </QueryClientProvider>
   );
 };


### PR DESCRIPTION
## 📝 상세 내용
명칭을 착각해서 Toast 보고 계속 Alert 거렸네요..

custom한 Toast를 간편하게 사용할 수 있도록 hook을 구현해보았습니다.

## #️⃣ 이슈 번호

- closes #23 

## 💬 리뷰 요구사항
현재 해당 Toast가 나타나는 위치를 왼쪽 아래로 설정했습니다. 그 이유는 두가지가 있는데요, 먼저 첫번째는 맥북의 경우 대부분의 알람이 우측 상단에 나타납니다. 두번째는 윈도우기반 컴퓨터 및 노트북의 경우 대부분의 알람이 우측 하단에 옵니다. 그래서 겹치지 않는 위치인 좌측 하단으로 선택해보았습니다. 
<img width="776" alt="스크린샷 2025-01-26 오전 5 15 55" src="https://github.com/user-attachments/assets/83146f67-47c6-402e-8e7c-99fc9b3f860f" />

그리고 저는 성공 / 실패 시 나타나는 Toast 밖에 생각이 안나는데, 나머지 case도 고려하는게 좋을까요???
저는 data 통신 성공 / 실패의 경우만 예기하긴 합니다

최대한 간편하게 사용할 수 있도록 Toast는 hook 으로 제작하였습니다. customToast로 간편하게 toast를 사용할 수 있습니다.

```typescript
const onSuccess = () => {
    customToast({
      toastStatus: 'success',
      toastTitle: '성공!',
      toastDescription: '작업이 성공적으로 완료되었습니다.',
    });
  };

  const onError = () => {
    customToast({
      toastStatus: 'error',
      toastTitle: '에러 발생!',
      toastDescription: '문제가 발생했습니다. 다시 시도해주세요.',
    });
  };
  ```
## ⏰ 현재 버그
x

## 📷 스크린샷(선택)
<img width="361" alt="image" src="https://github.com/user-attachments/assets/31274ab8-4d5b-4618-8400-5cae06c84dcb" />


## 🔗 참고 자료(선택)
https://www.notion.so/Toast-1862c5ccabe4803fb091c2a81211aab2?pvs=4
