### PR TITLE
issue#60 전체 ui 수정

### DIFF
--- a/src/pages/chat/components/modal/SetUserNameModal.tsx
+++ b/src/pages/chat/components/modal/SetUserNameModal.tsx
@@ -29,13 +29,13 @@ export const SetUserNameModal = ({ onComplete }: SetUserNameModalProps) => {
 
   return (
     <>
-      <Button mt='15px' h='36px' w='100px' onClick={onOpen}>
+      <Button mt='15px' h='36px' w='120px' onClick={onOpen}>
         채팅방 입장하기
       </Button>
 
       <Modal size='sm' isOpen={isOpen} onClose={onClose} isCentered>
         <ModalOverlay />
-        <ModalContent p='20px'>
+        <ModalContent py='20px'>
           <ModalHeader fontSize='13px' fontWeight='Bold'>
             입장할 닉네임을 설정해 주세요.
           </ModalHeader>

--- a/src/pages/chat/components/user/ChatUserSection.tsx
+++ b/src/pages/chat/components/user/ChatUserSection.tsx
@@ -12,7 +12,7 @@ export const ChatUserSection = ({ onGoBack }: ChatUserSectionProps) => {
         <Text w='full' textAlign='left' fontSize='24px' color='custom.blue' fontWeight={700}>
           현재 접속자
         </Text>
-        <Button h='32px' w='140px' px={5} onClick={onGoBack}>
+        <Button h='30px' w='150px' fontSize='sm' onClick={onGoBack}>
           채팅방 목록 보기
         </Button>
       </Flex>

--- a/src/pages/chat/ui/ChatPage.tsx
+++ b/src/pages/chat/ui/ChatPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { Box, Flex, Button, useMediaQuery } from '@chakra-ui/react';
 
+import { RouterPath } from '@shared/constants';
 import { breakPoints } from '@shared/styles';
 
 import { ChatRoomSection, ChatRoomInsideSection, ChatUserSection } from '../components';
@@ -37,7 +38,7 @@ export const ChatPage = () => {
         variant='outline'
         alignSelf='flex-end'
         onClick={() => {
-          navigate('/');
+          navigate(RouterPath.MAIN);
         }}
       >
         게시글 보기

--- a/src/pages/mypage/components/my-post/MyPostSection.tsx
+++ b/src/pages/mypage/components/my-post/MyPostSection.tsx
@@ -11,7 +11,7 @@ import { MOCK_MY_POST_LIST } from '../../data';
 export const MyPostSection = () => {
   const { data, isPending } = useGetMockData(MOCK_MY_POST_LIST);
   return (
-    <Grid columns={{ base: 1, sm: 2, md: 3 }} gap={20}>
+    <Grid columns={{ base: 1, md: 2, lg: 3 }} gap={20}>
       {isPending
         ? Array.from({ length: 6 }).map((_, index) => <SkeletonPostCards key={index} />)
         : data.content.map((post) => (

--- a/src/pages/mypage/components/profile/UserProfileSection.tsx
+++ b/src/pages/mypage/components/profile/UserProfileSection.tsx
@@ -1,4 +1,4 @@
-import { Flex, Button, Text, Box, Image } from '@chakra-ui/react';
+import { Flex, Button, Text, Box, Image, VStack } from '@chakra-ui/react';
 
 import { useGetMockData } from '@shared/hooks';
 
@@ -14,15 +14,16 @@ export const UserProfileSection = () => {
       ) : (
         <Flex
           w='full'
+          maxW={{ base: 'full', sm: '1000px' }}
           h={{ base: 'auto', sm: '210px' }}
           mt='30px'
           align='flex-start'
-          px={{ base: '30px', sm: '80px' }}
+          px={{ base: '10px', sm: '40px' }}
         >
           <Flex w={{ base: 'full', sm: '128px' }} flexDir='column' align='center'>
             <Image src={data.profile} boxSize={24} mb='16px' borderRadius='full' />
 
-            <Button w={{ base: '80px', sm: '110px' }} h='36px' fontSize='sm' mb='10px'>
+            <Button w={{ base: '100px', sm: '110px' }} h='36px' fontSize='sm' mb='10px'>
               이미지 업로드
             </Button>
             <Button
@@ -40,41 +41,41 @@ export const UserProfileSection = () => {
           </Flex>
 
           <Flex
-            w={{ base: 'full', sm: '150px' }}
-            flexDir='column'
+            w={{ base: 'full', sm: 'full' }}
             ml={{ base: '16px', sm: '30px' }}
-            align='flex-start'
+            justify='space-between'
           >
-            <Text w='150px' textAlign='left' fontSize='20px' fontWeight='Bold' mb='6px' mt='10px'>
-              {data.userNickname}
-            </Text>
-            <Box bg='none' border='none' cursor='pointer'>
-              <Text
-                w='full'
-                fontSize='sm'
-                fontWeight='Bold'
-                lineHeight='16px'
-                textAlign='center'
-                color='custom.blue'
-                textDecoration='underline'
-              >
-                닉네임 수정
+            <VStack w='full' align='start' spacing={1}>
+              <Text w='150px' textAlign='left' fontSize='20px' fontWeight='Bold' mb='6px' mt='10px'>
+                {data.userNickname}
               </Text>
-            </Box>
-          </Flex>
-
-          <Flex w='full' justify='flex-end' mt={{ base: '80px', sm: '0' }}>
-            <Button
-              variant='outline'
-              color='customGray.500'
-              borderColor='customGray.500'
-              w={{ base: '40px', sm: '80px' }}
-              h={{ base: '28px', sm: '32px' }}
-              fontSize='sm'
-              _hover={{}}
-            >
-              회원탈퇴
-            </Button>
+              <Box bg='none' border='none' cursor='pointer'>
+                <Text
+                  w='full'
+                  fontSize='sm'
+                  fontWeight='Bold'
+                  lineHeight='16px'
+                  textAlign='center'
+                  color='custom.blue'
+                  textDecoration='underline'
+                >
+                  닉네임 수정
+                </Text>
+              </Box>
+            </VStack>
+            <Flex align='center' mb={4}>
+              <Button
+                variant='outline'
+                color='customGray.500'
+                borderColor='customGray.500'
+                w={{ base: '60px', sm: '80px' }}
+                h={{ base: '28px', sm: '32px' }}
+                fontSize='sm'
+                _hover={{}}
+              >
+                회원탈퇴
+              </Button>
+            </Flex>
           </Flex>
         </Flex>
       )}

--- a/src/widgets/grid/Grid.tsx
+++ b/src/widgets/grid/Grid.tsx
@@ -3,7 +3,6 @@ import { SimpleGrid } from '@chakra-ui/react';
 import { breakPoints } from '@shared/styles';
 
 type ResponseGridStyle = {
-  // 'base' | 'xs' | 'sm' | 'md' | 'lg'
   [key in keyof typeof breakPoints]?: number;
 };
 


### PR DESCRIPTION
## 📝 상세 내용

전체 ui 수정 및 반응형 ui 수정

## #️⃣ 이슈 번호

- closes #60 

## 💬 리뷰 요구사항
### 마이페이지 모바일 ui
![스크린샷 2025-02-03 오전 1 08 53](https://github.com/user-attachments/assets/e9dfe8bf-100f-48bd-a278-73d025c9f36e)
### 마이페이지 PC UI
- max-width 설정으로 프로필 부분이 멀리 벌어지지 않게 수정
![스크린샷 2025-02-03 오전 1 09 48](https://github.com/user-attachments/assets/08a1fada-1258-4efd-8451-24a5d0004537)

### 채팅페이지
- 버튼 width 수정
- font-size 수정

전체적으로 모바일 화면에서 보이는 부분을 수정하였습니다. 또한 맥북과 PC 모니터 크기를 비교해서 최대한 유연하게 변형될 수 있도록 수정했습니다. 
채팅페이지의 경우 ui가 조금 수정되는것으로 알고 있어서, 수정 이후에 반응형 ui를 수정해야할 것 같습니다.

### fsd eslint
no-console-log 나 의존성 관리 부분에서는 사용하는게 좋아보였지만, fsd 자체가 프로젝트마다 성격이 조금씩 다르다는 특이성이 존재하기 때문에 eslint는 추가하지 않는 것이 좋을 것 같다는 생각이 들었습니다.

또한 eslint 로 규칙을 정하는 것 보다 PR에서 코드리뷰나 회의하면서 서로의 의견을 나누어 의존성 관리를 해보는 것이 이번 프로젝트에서는 더 좋은 방법이 될 것 같습니다.

따라서 이번 프로젝트에서는 eslint 설정을 더 추가하지 않을 계획입니다.
## ⏰ 현재 버그
x

## 📷 스크린샷(선택)
x

## 🔗 참고 자료(선택)
x
