### PR TITLE
issue#44 AI 코드리뷰 페이지 기능 구현

### DIFF
--- a/src/pages/code-review/apis/code-review.apis.ts
+++ b/src/pages/code-review/apis/code-review.apis.ts
@@ -1,10 +1,16 @@
 import { fetchInstance } from '@shared/service';
 
-import { ResponseCodeReview } from './code-review.type';
+import { ResponseCodeReview, RequestUploadReviewResult } from './code-review.type';
 
 export const getCodeReview = async (code: string): Promise<ResponseCodeReview> => {
   const response = await fetchInstance.post<ResponseCodeReview>('/ai/analyze', {
     body: JSON.stringify({ code }),
   });
   return response.data;
+};
+
+export const uploadReviewResult = async (data: RequestUploadReviewResult) => {
+  await fetchInstance.post('/posts', {
+    body: JSON.stringify(data),
+  });
 };

--- a/src/pages/code-review/apis/code-review.apis.ts
+++ b/src/pages/code-review/apis/code-review.apis.ts
@@ -1,0 +1,10 @@
+import { fetchInstance } from '@shared/service';
+
+import { ResponseCodeReview } from './code-review.type';
+
+export const getCodeReview = async (code: string): Promise<ResponseCodeReview> => {
+  const response = await fetchInstance.post<ResponseCodeReview>('/ai/analyze', {
+    body: JSON.stringify({ code }),
+  });
+  return response.data;
+};

--- a/src/pages/code-review/apis/code-review.type.ts
+++ b/src/pages/code-review/apis/code-review.type.ts
@@ -1,0 +1,19 @@
+export interface ResponseCodeReview {
+  candidates: Array<{
+    content: {
+      parts: Array<{
+        text: string;
+      }>;
+      role: string;
+    };
+    finishReason: string;
+    citationMetadata: {
+      citationSources: Array<{
+        startIndex: number;
+        endIndex: number;
+        uri: string;
+      }>;
+    };
+    avgLogprobs: number;
+  }>;
+}

--- a/src/pages/code-review/apis/code-review.type.ts
+++ b/src/pages/code-review/apis/code-review.type.ts
@@ -17,3 +17,10 @@ export interface ResponseCodeReview {
     avgLogprobs: number;
   }>;
 }
+
+export interface RequestUploadReviewResult {
+  title: string;
+  contents: string;
+  thumbnail: null;
+  summary: string;
+}

--- a/src/pages/code-review/apis/index.ts
+++ b/src/pages/code-review/apis/index.ts
@@ -1,0 +1,2 @@
+export * from './code-review.type';
+export * from './code-review.apis';

--- a/src/pages/code-review/components/codeinput/CodeInputBox.tsx
+++ b/src/pages/code-review/components/codeinput/CodeInputBox.tsx
@@ -1,5 +1,11 @@
-import { Flex, Text, Button, Input, Box } from '@chakra-ui/react';
+import { useState } from 'react';
 
+import { Flex, Text, Button, Input, Box, IconButton } from '@chakra-ui/react';
+
+import { ExternalLink, Copy } from 'lucide-react';
+
+import { ResponseCodeReview } from '../../apis';
+import { useCodeReview } from '../../hooks';
 import { locales } from '@blocknote/core';
 import { BlockNoteView } from '@blocknote/mantine';
 import { useCreateBlockNote } from '@blocknote/react';
@@ -22,6 +28,36 @@ export const CodeInputBox = () => {
     ],
   });
 
+  const [problemName, setProblemName] = useState<string>(''); // 문제 번호
+  const [codeReviewResult, setCodeReviewResult] = useState<ResponseCodeReview | null>(null);
+
+  const { mutate, isLoading, isError, error } = useCodeReview(); // react-query 훅 사용
+
+  const handleSubmit = () => {
+    const content = editor.document; // 현재 편집기의 내용을 JSON 형식으로 가져옴
+    // problemName을 주석으로 추가
+    const nameAddedContent = [
+      {
+        type: 'codeBlock',
+        content: `// 문제 번호: ${problemName}\n${content[0].content}`,
+      },
+      ...content.slice(1), // 나머지 블록 유지
+    ];
+    const parseDataToSend = {
+      code: JSON.stringify(nameAddedContent),
+    };
+
+    // 코드 리뷰 요청
+    mutate(parseDataToSend.code, {
+      onSuccess: (data) => {
+        setCodeReviewResult(data); // 코드 리뷰 결과 저장
+      },
+      onError: (error) => {
+        console.error('Code review failed:', error);
+      },
+    });
+  };
+
   return (
     <Flex direction='column' w='full' mt='60px' gap='5px'>
       <Text w='full' textAlign='left' color='custom.blue' fontSize='24px' fontWeight='Bold'>
@@ -30,7 +66,15 @@ export const CodeInputBox = () => {
       <Text w='full' textAlign='left' fontSize='16px' mb='5px' mt='20px'>
         리뷰하고 싶은 코드의 문제 번호를 적어 주세요.
       </Text>
-      <Input bg='white' color='black' w='full' h='36px' placeholder='ex) 백준 11033번' />
+      <Input
+        bg='white'
+        color='black'
+        w='full'
+        h='36px'
+        placeholder='ex) 백준 11033번'
+        value={problemName}
+        onChange={(e) => setProblemName(e.target.value)}
+      />
 
       <Text w='full' textAlign='left' fontSize='16px' mb='5px' mt='20px'>
         리뷰하고 싶은 코드를 입력해주세요. 코드 리뷰 결과는 Markdown 언어로 제공됩니다.
@@ -52,9 +96,36 @@ export const CodeInputBox = () => {
         mt='10px'
         fontSize='14px'
         alignSelf='flex-end'
+        onClick={handleSubmit}
       >
         AI 코드리뷰
       </Button>
+
+      <Flex direction='column' w='full' mt='28px' gap='5px'>
+        <Text w='full' textAlign='left' color='custom.blue' fontSize='24px' fontWeight='Bold'>
+          코드 리뷰 결과
+        </Text>
+        <Flex mt='20px'>
+          <Text w='full' textAlign='left' fontSize='16px' mb='5px'>
+            게시물로 작성하거나 복사해서 코드 리뷰를 활용해보세요!
+          </Text>
+          <IconButton aria-label='copy' boxSize='24px' icon={<Copy size={16} />}></IconButton>
+        </Flex>
+        <Box bg='white' color='black' w='full' h='600px' overflow='auto'>
+          {codeReviewResult && <pre>{codeReviewResult.candidates[0].content.parts[0].text}</pre>}
+        </Box>
+        <Button
+          leftIcon={<ExternalLink size={16} />}
+          colorScheme='custom.blue'
+          w='124px'
+          h='32px'
+          mt='10px'
+          fontSize='14px'
+          alignSelf='flex-end'
+        >
+          게시글로 올리기
+        </Button>
+      </Flex>
     </Flex>
   );
 };

--- a/src/pages/code-review/components/codeinput/CodeInputBox.tsx
+++ b/src/pages/code-review/components/codeinput/CodeInputBox.tsx
@@ -36,7 +36,7 @@ export const CodeInputBox = () => {
   const [problemName, setProblemName] = useState<string>(''); // 문제 번호
   const [codeReviewResult, setCodeReviewResult] = useState<ResponseCodeReview | null>(null);
 
-  const { mutate, isPending, isError, error } = useCodeReview(); // react-query 훅 사용
+  const { mutate, isPending } = useCodeReview(); // react-query 훅 사용
   const customToast = useCustomToast(); // 커스텀 토스트 훅
 
   const handleSubmit = () => {

--- a/src/pages/code-review/components/codeinput/CodeInputBox.tsx
+++ b/src/pages/code-review/components/codeinput/CodeInputBox.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
 
-import { Flex, Text, Button, Input, Box, IconButton } from '@chakra-ui/react';
+import { Flex, Text, Button, Input, Box, IconButton, Spinner } from '@chakra-ui/react';
 
 import { ExternalLink, Copy } from 'lucide-react';
+
+import { useCustomToast } from '@shared/hooks';
 
 import { ResponseCodeReview } from '../../apis';
 import { useCodeReview } from '../../hooks';
@@ -58,6 +60,31 @@ export const CodeInputBox = () => {
     });
   };
 
+  const customToast = useCustomToast();
+
+  // 클립보드 복사 함수
+  const handleCopyToClipboard = () => {
+    if (codeReviewResult) {
+      const textToCopy = codeReviewResult.candidates[0].content.parts[0].text;
+      navigator.clipboard
+        .writeText(textToCopy)
+        .then(() => {
+          customToast({
+            toastStatus: 'success',
+            toastTitle: '성공!',
+            toastDescription: '작업이 성공적으로 완료되었습니다.',
+          });
+        })
+        .catch(() => {
+          customToast({
+            toastStatus: 'error',
+            toastTitle: '복사 실패',
+            toastDescription: '클립보드 복사에 실패했습니다',
+          });
+        });
+    }
+  };
+
   return (
     <Flex direction='column' w='full' mt='60px' gap='5px'>
       <Text w='full' textAlign='left' color='custom.blue' fontSize='24px' fontWeight='Bold'>
@@ -97,8 +124,9 @@ export const CodeInputBox = () => {
         fontSize='14px'
         alignSelf='flex-end'
         onClick={handleSubmit}
+        disabled={isLoading} // 로딩 중 버튼 비활성화
       >
-        AI 코드리뷰
+        {isLoading ? <Spinner size='sm' /> : 'AI 코드리뷰'}
       </Button>
 
       <Flex direction='column' w='full' mt='28px' gap='5px'>
@@ -109,7 +137,12 @@ export const CodeInputBox = () => {
           <Text w='full' textAlign='left' fontSize='16px' mb='5px'>
             게시물로 작성하거나 복사해서 코드 리뷰를 활용해보세요!
           </Text>
-          <IconButton aria-label='copy' boxSize='24px' icon={<Copy size={16} />}></IconButton>
+          <IconButton
+            aria-label='copy'
+            boxSize='24px'
+            icon={<Copy size={16} />}
+            onClick={handleCopyToClipboard}
+          ></IconButton>
         </Flex>
         <Box bg='white' color='black' w='full' h='600px' overflow='auto'>
           {codeReviewResult && <pre>{codeReviewResult.candidates[0].content.parts[0].text}</pre>}

--- a/src/pages/code-review/components/codeinput/CodeInputBox.tsx
+++ b/src/pages/code-review/components/codeinput/CodeInputBox.tsx
@@ -1,6 +1,27 @@
-import { Flex, Text, Textarea, Button, Input } from '@chakra-ui/react';
+import { Flex, Text, Button, Input, Box } from '@chakra-ui/react';
+
+import { locales } from '@blocknote/core';
+import { BlockNoteView } from '@blocknote/mantine';
+import { useCreateBlockNote } from '@blocknote/react';
 
 export const CodeInputBox = () => {
+  const locale = locales['en'];
+  const editor = useCreateBlockNote({
+    dictionary: {
+      ...locale,
+      placeholders: {
+        ...locale.placeholders,
+        default: '글을 작성해주세요...',
+      },
+    },
+    initialContent: [
+      {
+        type: 'codeBlock',
+        content: '',
+      },
+    ],
+  });
+
   return (
     <Flex direction='column' w='full' mt='60px' gap='5px'>
       <Text w='full' textAlign='left' color='custom.blue' fontSize='24px' fontWeight='Bold'>
@@ -14,8 +35,16 @@ export const CodeInputBox = () => {
       <Text w='full' textAlign='left' fontSize='16px' mb='5px' mt='20px'>
         리뷰하고 싶은 코드를 입력해주세요. 코드 리뷰 결과는 Markdown 언어로 제공됩니다.
       </Text>
-
-      <Textarea bg='white' color='black' w='full' h='600px' placeholder='코드를 입력해 주세요.' />
+      <Flex flexDir='column' w='full' h='auto' background='white' textAlign='left'>
+        <Box h='auto' overflow='auto' mt='10px' mb='10px'>
+          <BlockNoteView
+            editor={editor}
+            sideMenu={false} // 사이드 메뉴 비활성화
+            formattingToolbar={false} // 포맷팅 툴바 비활성화
+            slashMenu={false} // 슬래시 메뉴 비활성화
+          />
+        </Box>
+      </Flex>
       <Button
         colorScheme='custom.blue'
         w='96px'

--- a/src/pages/code-review/components/codeinput/CodeInputBox.tsx
+++ b/src/pages/code-review/components/codeinput/CodeInputBox.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text, Textarea, Button } from '@chakra-ui/react';
+import { Flex, Text, Textarea, Button, Input } from '@chakra-ui/react';
 
 export const CodeInputBox = () => {
   return (
@@ -6,9 +6,15 @@ export const CodeInputBox = () => {
       <Text w='full' textAlign='left' color='custom.blue' fontSize='24px' fontWeight='Bold'>
         코드 작성하기
       </Text>
-      <Text w='full' textAlign='left' fontSize='16px' mb='5px'>
+      <Text w='full' textAlign='left' fontSize='16px' mb='5px' mt='20px'>
+        리뷰하고 싶은 코드의 문제 번호를 적어 주세요.
+      </Text>
+      <Input bg='white' color='black' w='full' h='36px' placeholder='ex) 백준 11033번' />
+
+      <Text w='full' textAlign='left' fontSize='16px' mb='5px' mt='20px'>
         리뷰하고 싶은 코드를 입력해주세요. 코드 리뷰 결과는 Markdown 언어로 제공됩니다.
       </Text>
+
       <Textarea bg='white' color='black' w='full' h='600px' placeholder='코드를 입력해 주세요.' />
       <Button
         colorScheme='custom.blue'

--- a/src/pages/code-review/components/codeinput/CodeInputBox.tsx
+++ b/src/pages/code-review/components/codeinput/CodeInputBox.tsx
@@ -17,7 +17,7 @@ export const CodeInputBox = () => {
       ...locale,
       placeholders: {
         ...locale.placeholders,
-        default: '글을 작성해주세요...',
+        default: '코드 블락(검정 박스) 안에 작성해 주세요',
       },
     },
     initialContent: [
@@ -44,7 +44,7 @@ export const CodeInputBox = () => {
       ...content.slice(1), // 나머지 블록 유지
     ];
     const parseDataToSend = {
-      code: JSON.stringify(nameAddedContent),
+      code: JSON.stringify(nameAddedContent[0].content),
     };
 
     // 코드 리뷰 요청

--- a/src/pages/code-review/components/result/ReviewResult.tsx
+++ b/src/pages/code-review/components/result/ReviewResult.tsx
@@ -8,7 +8,7 @@ export const ReviewResult = () => {
       <Text w='full' textAlign='left' color='custom.blue' fontSize='24px' fontWeight='Bold'>
         코드 리뷰 결과
       </Text>
-      <Flex>
+      <Flex mt='20px'>
         <Text w='full' textAlign='left' fontSize='16px' mb='5px'>
           게시물로 작성하거나 복사해서 코드 리뷰를 활용해보세요!
         </Text>

--- a/src/pages/code-review/hooks/index.ts
+++ b/src/pages/code-review/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useCodeReview';

--- a/src/pages/code-review/hooks/useCodeReview.ts
+++ b/src/pages/code-review/hooks/useCodeReview.ts
@@ -1,0 +1,9 @@
+// useCodeReview.ts
+import { getCodeReview } from '../apis';
+import { useMutation } from '@tanstack/react-query';
+
+export const useCodeReview = () => {
+  return useMutation({
+    mutationFn: (code: string) => getCodeReview(code),
+  });
+};

--- a/src/pages/code-review/index.ts
+++ b/src/pages/code-review/index.ts
@@ -1,1 +1,4 @@
 export * from './ui';
+export * from './apis';
+export * from './components';
+export * from './hooks';

--- a/src/pages/code-review/ui/CodeReviewPage.tsx
+++ b/src/pages/code-review/ui/CodeReviewPage.tsx
@@ -1,13 +1,12 @@
 import { Flex } from '@chakra-ui/react';
 
-import { CodeInputBox, ReviewResult } from '../components';
+import { CodeInputBox } from '../components';
 
 export const CodeReviewPage = () => {
   return (
     <Flex w='full' justify='center' overflow={{ base: 'scroll', sm: 'hidden' }}>
       <Flex w={{ base: 'full', sm: '80%' }} flexDir='column' align='center' mb='100px'>
         <CodeInputBox />
-        <ReviewResult />
       </Flex>
     </Flex>
   );

--- a/src/pages/code-review/ui/CodeReviewPage.tsx
+++ b/src/pages/code-review/ui/CodeReviewPage.tsx
@@ -5,7 +5,7 @@ import { CodeInputBox, ReviewResult } from '../components';
 export const CodeReviewPage = () => {
   return (
     <Flex w='full' justify='center' overflow={{ base: 'scroll', sm: 'hidden' }}>
-      <Flex w='80%' flexDir='column' align='center' mb='100px'>
+      <Flex w={{ base: 'full', sm: '80%' }} flexDir='column' align='center' mb='100px'>
         <CodeInputBox />
         <ReviewResult />
       </Flex>


### PR DESCRIPTION
## 📝 상세 내용

- AI 코드리뷰 페이지 블락노트 삽입 및 uploadReviewResult 훅 작성
- useCreateBlockNote 구현
- 코드리뷰 결과물 복사하기 기능 구현
- 게시물로 바로 작성하기 api 연동

## #️⃣ 이슈 번호

- resolves #44 

## 💬 리뷰 요구사항

블락노트에서 block type이 코드로만 작성할 수 있듯이 보이게는 해뒀는데, 백엔드에서 테스트해볼 땐 textarea로 해서 일단 api 테스트 해볼 때 이 부분 그대로 갈지, 고칠지 결정해야 할 것 같아요.
api 테스트가 같은 도메인에서만 가능해서, 테스트해 볼 수가 없어서 머지 후에, 테스트를 확인할 수 있을 것 같습니다.

## ⏰ 현재 버그


## 📷 스크린샷(선택)

<img width="1128" alt="image" src="https://github.com/user-attachments/assets/8bae4c1c-8c32-4771-8304-ff89e7ab8332" />

<img width="1062" alt="image" src="https://github.com/user-attachments/assets/79aa86d8-0cf8-4f8a-8759-1a4679924c82" />


## 🔗 참고 자료(선택)

