### PR TITLE
issue#81 게시글 작성, 수정 페이지 오류 해결

### DIFF
--- a/src/pages/post-edit/apis/post-edit.api.ts
+++ b/src/pages/post-edit/apis/post-edit.api.ts
@@ -19,9 +19,9 @@ export const updatePost = async (
   return response.data;
 };
 
-export const updatePostTags = async (postId: number, tagId: number[]) => {
+export const updatePostTags = async (postId: number, tagIds: number[]) => {
   const response = await fetchInstance.put(`${POSTS_PATH}/${postId}/tags`, {
-    body: JSON.stringify({ tagId }),
+    body: JSON.stringify({ tagIds }),
   });
 
   return response.data;

--- a/src/pages/post-edit/ui/PostEditPage.tsx
+++ b/src/pages/post-edit/ui/PostEditPage.tsx
@@ -1,19 +1,20 @@
 import { useEffect, useState } from 'react';
 import { FieldErrors, useForm } from 'react-hook-form';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { Box, useDisclosure, VStack } from '@chakra-ui/react';
 
 import { getPostDetail, getPostTags } from '@pages/post-detail/apis';
 
 import { PostTitle, PostTag, PostContent, PostButtons, Form } from '@shared/components';
+import { RouterPath } from '@shared/constants';
 import { useCustomToast } from '@shared/hooks';
 import { PostFormData } from '@shared/types';
 
 import { PostModal } from '@widgets/modals';
-import { LoadingView } from '@widgets/view';
 
 import { updatePost, updatePostTags } from '../apis';
+import { SkeletonPostEditPage } from './SkeletonPostEditPage';
 import { useQuery } from '@tanstack/react-query';
 
 export const PostEditPage = () => {
@@ -21,6 +22,7 @@ export const PostEditPage = () => {
   const { postId } = useParams<{ postId: string }>();
   const customToast = useCustomToast();
   const [hasErrorToastShown, setHasErrorToastShown] = useState(false);
+  const navigate = useNavigate();
 
   const {
     data: postDetail,
@@ -80,28 +82,21 @@ export const PostEditPage = () => {
   const onUpdatePostButton = async (modalData: { thumbnail: string; summary: string }) => {
     try {
       const data = form.getValues();
-      console.log('게시글 데이터 제출:', data);
-
-      const updatedPost = await updatePost(Number(postId), {
+      await updatePost(Number(postId), {
         title: data.title,
         contents: data.content,
         thumbnail: modalData.thumbnail,
         summary: modalData.summary,
       });
-
-      console.log('게시글 수정 성공:', updatedPost);
-
       if (data.tag !== null && data.tag !== undefined) {
         await updatePostTags(Number(postId), data.tag);
       }
-
       customToast({
         toastStatus: 'success',
         toastTitle: '게시글 수정 완료',
         toastDescription: '게시글이 성공적으로 수정되었습니다!',
       });
-
-      onClose();
+      navigate(RouterPath.MAIN);
     } catch (error) {
       console.error('게시글 수정 실패:', error);
       customToast({
@@ -134,7 +129,7 @@ export const PostEditPage = () => {
     }
   };
 
-  if (isPostLoading || isTagsLoading) return <LoadingView />;
+  if (isPostLoading || isTagsLoading) return <SkeletonPostEditPage />;
   if (!postDetail || !postTag) return <Box>데이터를 불러올 수 없습니다.</Box>;
 
   return (

--- a/src/pages/post-edit/ui/SkeletonPostEditPage.tsx
+++ b/src/pages/post-edit/ui/SkeletonPostEditPage.tsx
@@ -1,0 +1,14 @@
+import { VStack, Skeleton, SkeletonText, Box } from '@chakra-ui/react';
+
+export const SkeletonPostEditPage = () => {
+  return (
+    <VStack w='full' py='20px' px='30px' gap='4' align='start' bg='white'>
+      <Skeleton height='40px' width='80%' borderRadius='5px' mt={10} />
+      <Skeleton height='40px' width='40%' borderRadius='5px' />
+      <Box w='full'>
+        <SkeletonText noOfLines={50} spacing='4' skeletonHeight='16px' />
+      </Box>
+      <Skeleton height='50px' width='120px' borderRadius='5px' />
+    </VStack>
+  );
+};

--- a/src/pages/post-write/apis/post-write.api.ts
+++ b/src/pages/post-write/apis/post-write.api.ts
@@ -24,9 +24,9 @@ export const createPost = async (postData: {
   return response.data;
 };
 
-export const savePostTags = async (postId: number, tagId: number[] | null) => {
+export const savePostTags = async (postId: number, tagIds: number[] | null) => {
   const response = await fetchInstance.post(`${POSTS_PATH}/${postId}/tags`, {
-    body: JSON.stringify({ tagId }),
+    body: JSON.stringify({ tagIds }),
     headers: {
       'Content-Type': 'application/json',
     },

--- a/src/pages/post-write/ui/PostWritePage.tsx
+++ b/src/pages/post-write/ui/PostWritePage.tsx
@@ -1,8 +1,10 @@
 import { useForm, FieldErrors } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
 
 import { useDisclosure, VStack } from '@chakra-ui/react';
 
 import { Form, PostTitle, PostTag, PostContent, PostButtons } from '@shared/components';
+import { RouterPath } from '@shared/constants';
 import { useCustomToast } from '@shared/hooks';
 import { PostFormData } from '@shared/types';
 
@@ -20,7 +22,7 @@ export const PostWritePage = () => {
       summary: '',
     },
   });
-
+  const navigate = useNavigate();
   const customToast = useCustomToast();
   const { isOpen, onOpen, onClose } = useDisclosure();
 
@@ -39,21 +41,15 @@ export const PostWritePage = () => {
         thumbnail: modalData.thumbnail,
         summary: modalData.summary,
       });
-
-      console.log('게시글 생성 성공:', createdPost);
-
       if (createdPost?.id) {
         await savePostTags(createdPost.id, data.tag);
-        console.log('태그 저장 성공');
       }
-
       customToast({
         toastStatus: 'success',
         toastTitle: '게시글 출간 완료',
         toastDescription: '게시글이 성공적으로 출간되었습니다!',
       });
-
-      onClose();
+      navigate(RouterPath.MAIN);
     } catch (error) {
       console.error('게시글 출간 실패:', error);
       customToast({

--- a/src/pages/post-write/ui/PostWritePage.tsx
+++ b/src/pages/post-write/ui/PostWritePage.tsx
@@ -33,8 +33,6 @@ export const PostWritePage = () => {
   const onCreatePostButton = async (modalData: { thumbnail: string; summary: string }) => {
     try {
       const data = methods.getValues();
-      console.log('게시글 데이터 제출:', data);
-
       const createdPost = await createPost({
         title: data.title,
         contents: data.content,

--- a/src/shared/components/post-form/post-content/ui/PostContent.tsx
+++ b/src/shared/components/post-form/post-content/ui/PostContent.tsx
@@ -22,25 +22,6 @@ export const PostContent = ({ contents }: PostContentFieldEditorProps) => {
   const { control } = useFormContext();
   const isMobile = useBreakpointValue({ base: true, md: false });
 
-  function generateStorageId(): string {
-    const lettersAndNumbers: string =
-      'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-
-    let result: string = '';
-
-    for (let i = 0; i < 10; i++) {
-      result += lettersAndNumbers.charAt(Math.floor(Math.random() * lettersAndNumbers.length));
-    }
-
-    return result
-      .split('')
-      .sort(() => Math.random() - 0.5)
-      .join('');
-  }
-
-  const storageId: string = generateStorageId();
-  console.log(storageId);
-
   const uploadFile = async (file: File): Promise<string> => {
     const formData = new FormData();
     formData.append('file', file);

--- a/src/shared/components/post-form/post-tag/ui/PostTag.tsx
+++ b/src/shared/components/post-form/post-tag/ui/PostTag.tsx
@@ -23,10 +23,10 @@ export const PostTag = ({ tag }: PostTagProps) => {
 
   const toggleTag = (tagId: number) => {
     const updatedTags = selectedTags.includes(tagId)
-      ? selectedTags.filter((id) => id !== tagId) // 이미 선택된 태그는 제거
-      : [...selectedTags, tagId]; // 새로운 태그 추가
+      ? selectedTags.filter((id) => id !== tagId)
+      : [...selectedTags, tagId];
 
-    setValue('tag', updatedTags); // ✅ 다중 선택된 태그 배열을 `setValue`에 저장
+    setValue('tag', updatedTags);
   };
 
   return (
@@ -64,7 +64,7 @@ export const PostTag = ({ tag }: PostTagProps) => {
                   borderColor={
                     selectedTags.includes(tag.id) ? `${tag.color}.400` : `${tag.color}.500`
                   }
-                  onClick={() => toggleTag(tag.id)} // ✅ 클릭 시 `toggleTag` 호출
+                  onClick={() => toggleTag(tag.id)}
                 >
                   {tag.label}
                 </Button>

--- a/src/widgets/modals/PostModal.tsx
+++ b/src/widgets/modals/PostModal.tsx
@@ -41,7 +41,7 @@ type PostModalProps = {
     contents: string;
     thumbnail: string;
     summary: string;
-  }) => void;
+  }) => Promise<void>;
   imageUrl?: string;
 };
 
@@ -63,6 +63,7 @@ export const PostModal = ({
 }: PostModalProps) => {
   const imgRef = useRef<HTMLInputElement | null>(null);
   const [isUploading, setIsUploading] = useState(false);
+  const [isPosting, setIsPosting] = useState(false);
   const MAX_IMAGE_SIZE_BYTES = 1024 * 1024 * 2;
   const customToast = useCustomToast();
 
@@ -136,13 +137,18 @@ export const PostModal = ({
     setValue('thumbnail', '');
   };
 
-  const onSubmit = (data: PostModalForm) => {
-    onConfirmButton({
-      title,
-      contents: postContent,
-      thumbnail: data.thumbnail,
-      summary: data.summary,
-    });
+  const onSubmit = async (data: PostModalForm) => {
+    setIsPosting(true);
+    try {
+      await onConfirmButton({
+        title,
+        contents: postContent,
+        thumbnail: data.thumbnail,
+        summary: data.summary,
+      });
+    } finally {
+      setIsPosting(false);
+    }
   };
 
   return (
@@ -152,7 +158,7 @@ export const PostModal = ({
         <ModalHeader mt={5} textAlign='left' ml='3'>
           포스트 미리보기
         </ModalHeader>
-        <ModalCloseButton />
+        {!isPosting && <ModalCloseButton />}
 
         <Form {...form}>
           <form onSubmit={handleSubmit(onSubmit)}>
@@ -198,6 +204,7 @@ export const PostModal = ({
                             color: 'white',
                             transition: 'all 0.2s ease-in-out',
                           }}
+                          isDisabled={isPosting}
                         >
                           썸네일 업로드
                           <Input
@@ -233,6 +240,7 @@ export const PostModal = ({
                           maxLength={150}
                           placeholder='나의 포스트를 짧게 소개해보아요.'
                           fontSize='sm'
+                          isDisabled={isPosting}
                         />
                         <Flex w='full' justify='flex-end' mt='2px'>
                           <Text as='b' fontSize='sm' color='customGray.500'>
@@ -256,6 +264,7 @@ export const PostModal = ({
                   h='40px'
                   colorScheme='custom.blue'
                   onClick={onClose}
+                  isDisabled={isPosting}
                 >
                   취소
                 </Button>
@@ -267,8 +276,9 @@ export const PostModal = ({
                   colorScheme='custom.blue'
                   _hover={{}}
                   type='submit'
+                  isDisabled={isPosting}
                 >
-                  {buttonTitle}
+                  {isPosting ? '출간 중...' : buttonTitle}
                 </Button>
               </HStack>
             </ModalFooter>

--- a/src/widgets/modals/PostModal.tsx
+++ b/src/widgets/modals/PostModal.tsx
@@ -278,7 +278,7 @@ export const PostModal = ({
                   type='submit'
                   isDisabled={isPosting}
                 >
-                  {isPosting ? '출간 중...' : buttonTitle}
+                  {isPosting ? '저장 중...' : buttonTitle}
                 </Button>
               </HStack>
             </ModalFooter>


### PR DESCRIPTION
## 📝 상세 내용
게시글 작성, 수정 페이지에서 저장 시 toast에 오류 발생 뜨는 것 해결했습니다. -> api에 변수 이름을 tagIds인데 tagId라고 잘못 적어서 뜨는 오류였음. 결국 Tag는 제대로 저장이 안되고 있었음.. 이제 오류 고쳐져서 게시글도 저장되고, 태그도 잘 저장됨.
스켈레톤 코드 구현함. 그냥 스켈레톤 코드 파일을 새로 만들어서 로딩 중에는 그 컴포넌트가 보이게 함.
이미지가 storageId가 없어야 저장이 되고 있음. 그래서 storageId를 쓰는 건지 안쓰는 건지 모르겠음. (처음에 이거 쓰자고 한 이유는 db에 이미지 파일에 계속 쌓여서 지워줄 때 storageId 별로 지우자고 해서 프론트에서 만듦) 암튼 이거 지움. 로컬에서는 이미지 잘 보임. 썸네일도 잘 저장됨.


## #️⃣ 이슈 번호
close #81 

## 💬 리뷰 요구사항


## ⏰ 현재 버그


## 📷 스크린샷(선택)


## 🔗 참고 자료(선택)

