### PR TITLE
issue#91 게시글 작성/수정 페이지 이미지 업로드 오류 수정

### DIFF
--- a/src/pages/post-detail/apis/post-detail.type.ts
+++ b/src/pages/post-detail/apis/post-detail.type.ts
@@ -9,6 +9,7 @@ export type ResponsePostDetail = {
   createdAt: string;
   updatedAt: string;
   author: string;
+  storageId: string;
 };
 
 export type ResponsePostTags = {

--- a/src/pages/post-edit/ui/PostEditPage.tsx
+++ b/src/pages/post-edit/ui/PostEditPage.tsx
@@ -137,7 +137,7 @@ export const PostEditPage = () => {
       <VStack w='full' py='20px' gap='0'>
         <PostTitle />
         <PostTag />
-        <PostContent contents={postDetail.contents} />
+        <PostContent contents={postDetail.contents} storageId={postDetail.storageId} />
         <PostButtons buttonText='수정하기' onClick={form.handleSubmit(onSubmit, onInvalid)} />
         <PostModal
           title={form.watch('title')}
@@ -149,6 +149,7 @@ export const PostEditPage = () => {
           imageUrl={form.watch('thumbnail')}
           postSummary={form.watch('summary')}
           onConfirmButton={onUpdatePostButton}
+          storageId={postDetail.storageId}
         />
       </VStack>
     </Form>

--- a/src/pages/post-write/apis/post-write.api.ts
+++ b/src/pages/post-write/apis/post-write.api.ts
@@ -9,6 +9,7 @@ export const createPost = async (postData: {
   contents: string;
   thumbnail: string;
   summary: string;
+  storageId: string;
 }): Promise<CreatePostResponse> => {
   const response = await fetchInstance.post<CreatePostResponse>(`${POSTS_PATH}`, {
     body: JSON.stringify(postData),
@@ -33,4 +34,9 @@ export const savePostTags = async (postId: number, tagIds: number[] | null) => {
   });
 
   return response.data;
+};
+
+export const getStorageId = async (): Promise<string> => {
+  const response = await fetchInstance.get<{ storageId: string }>('/make/uuid');
+  return response.data.storageId;
 };

--- a/src/pages/post-write/apis/post-write.type.ts
+++ b/src/pages/post-write/apis/post-write.type.ts
@@ -4,4 +4,5 @@ export type CreatePostResponse = {
   contents: string;
   thumbnail: string;
   summary: string;
+  storageId: string;
 };

--- a/src/pages/post-write/ui/PostWritePage.tsx
+++ b/src/pages/post-write/ui/PostWritePage.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { useForm, FieldErrors } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 
@@ -10,7 +11,7 @@ import { PostFormData } from '@shared/types';
 
 import { PostModal } from '@widgets/modals';
 
-import { createPost, savePostTags } from '../apis';
+import { createPost, savePostTags, getStorageId } from '../apis';
 
 export const PostWritePage = () => {
   const methods = useForm<PostFormData>({
@@ -25,6 +26,19 @@ export const PostWritePage = () => {
   const navigate = useNavigate();
   const customToast = useCustomToast();
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const [storageId, setStorageId] = useState<string | '임시'>('임시');
+
+  useEffect(() => {
+    const fetchStorageId = async () => {
+      try {
+        const id = await getStorageId();
+        setStorageId(id);
+      } catch (error) {
+        console.error('storageId 불러오기 실패:', error);
+      }
+    };
+    fetchStorageId();
+  }, []);
 
   const onSubmit = () => {
     onOpen();
@@ -38,6 +52,7 @@ export const PostWritePage = () => {
         contents: data.content,
         thumbnail: modalData.thumbnail,
         summary: modalData.summary,
+        storageId,
       });
       if (createdPost?.id) {
         await savePostTags(createdPost.id, data.tag);
@@ -85,7 +100,7 @@ export const PostWritePage = () => {
       <VStack w='full' py='20px' gap='0' as='form'>
         <PostTitle />
         <PostTag />
-        <PostContent />
+        <PostContent storageId={storageId} />
         <PostButtons buttonText='작성완료' onClick={methods.handleSubmit(onSubmit, onInvalid)} />
         <PostModal
           title={methods.watch('title')}
@@ -97,6 +112,7 @@ export const PostWritePage = () => {
           imageUrl={methods.watch('thumbnail')}
           postSummary={methods.watch('summary')}
           onConfirmButton={onCreatePostButton}
+          storageId={storageId}
         />
       </VStack>
     </Form>

--- a/src/pages/post-write/ui/PostWritePage.tsx
+++ b/src/pages/post-write/ui/PostWritePage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useForm, FieldErrors } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 
-import { useDisclosure, VStack } from '@chakra-ui/react';
+import { Text, Box, useDisclosure, VStack } from '@chakra-ui/react';
 
 import { Form, PostTitle, PostTag, PostContent, PostButtons } from '@shared/components';
 import { RouterPath } from '@shared/constants';
@@ -26,7 +26,7 @@ export const PostWritePage = () => {
   const navigate = useNavigate();
   const customToast = useCustomToast();
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const [storageId, setStorageId] = useState<string | '임시'>('임시');
+  const [storageId, setStorageId] = useState<string | null>(null);
 
   useEffect(() => {
     const fetchStorageId = async () => {
@@ -41,12 +41,23 @@ export const PostWritePage = () => {
   }, []);
 
   const onSubmit = () => {
+    if (!storageId) {
+      customToast({
+        toastStatus: 'error',
+        toastTitle: '게시글 작성 페이지',
+        toastDescription: '잠시 후 다시 시도해주세요.',
+      });
+      return;
+    }
     onOpen();
   };
 
   const onCreatePostButton = async (modalData: { thumbnail: string; summary: string }) => {
     try {
       const data = methods.getValues();
+      if (!storageId) {
+        throw new Error('storageId가 설정되지 않았습니다.');
+      }
       const createdPost = await createPost({
         title: data.title,
         contents: data.content,
@@ -59,7 +70,7 @@ export const PostWritePage = () => {
       }
       customToast({
         toastStatus: 'success',
-        toastTitle: '게시글 출간 완료',
+        toastTitle: '게시글 작성 페이지',
         toastDescription: '게시글이 성공적으로 출간되었습니다!',
       });
       navigate(RouterPath.MAIN);
@@ -67,7 +78,7 @@ export const PostWritePage = () => {
       console.error('게시글 출간 실패:', error);
       customToast({
         toastStatus: 'error',
-        toastTitle: '출간 실패',
+        toastTitle: '게시글 작성 페이지',
         toastDescription: '게시글 출간 중 오류가 발생했습니다.',
       });
     }
@@ -77,19 +88,19 @@ export const PostWritePage = () => {
     if (errors.title) {
       customToast({
         toastStatus: 'error',
-        toastTitle: '게시물 작성',
+        toastTitle: '게시물 작성 페이지',
         toastDescription: '제목을 입력해주세요!',
       });
     } else if (errors.tag) {
       customToast({
         toastStatus: 'error',
-        toastTitle: '태그 선택 필요',
+        toastTitle: '게시글 작성 페이지',
         toastDescription: '태그를 선택해주세요!',
       });
     } else if (errors.content) {
       customToast({
         toastStatus: 'error',
-        toastTitle: '내용 입력 필요',
+        toastTitle: '게시글 작성 페이지',
         toastDescription: '내용을 입력해주세요!',
       });
     }
@@ -100,20 +111,37 @@ export const PostWritePage = () => {
       <VStack w='full' py='20px' gap='0' as='form'>
         <PostTitle />
         <PostTag />
-        <PostContent storageId={storageId} />
+        {storageId ? (
+          <PostContent storageId={storageId} />
+        ) : (
+          <Box
+            bg='white'
+            w='full'
+            h={{ base: '400px', md: '600px' }}
+            pt='12px'
+            pl={{ base: '10px', md: '50px' }}
+            textAlign='start'
+          >
+            <Text color='customGray.400' fontStyle='italic' fontSize='lg'>
+              게시글 작성을 위한 준비 중입니다... 잠시만 기다려주세요!
+            </Text>
+          </Box>
+        )}
         <PostButtons buttonText='작성완료' onClick={methods.handleSubmit(onSubmit, onInvalid)} />
-        <PostModal
-          title={methods.watch('title')}
-          isOpen={isOpen}
-          onClose={onClose}
-          buttonTitle='출간하기'
-          postType='create'
-          postContent={methods.watch('content')}
-          imageUrl={methods.watch('thumbnail')}
-          postSummary={methods.watch('summary')}
-          onConfirmButton={onCreatePostButton}
-          storageId={storageId}
-        />
+        {storageId && (
+          <PostModal
+            title={methods.watch('title')}
+            isOpen={isOpen}
+            onClose={onClose}
+            buttonTitle='출간하기'
+            postType='create'
+            postContent={methods.watch('content')}
+            imageUrl={methods.watch('thumbnail')}
+            postSummary={methods.watch('summary')}
+            onConfirmButton={onCreatePostButton}
+            storageId={storageId}
+          />
+        )}
       </VStack>
     </Form>
   );

--- a/src/shared/components/post-form/post-content/ui/PostContent.tsx
+++ b/src/shared/components/post-form/post-content/ui/PostContent.tsx
@@ -27,6 +27,7 @@ export const PostContent = ({ contents, storageId }: PostContentFieldEditorProps
     const formData = new FormData();
     formData.append('file', file);
     formData.append('storageId', String(storageId));
+    console.log('StorageId', storageId); // ✅ StorageId 확인
 
     try {
       const response = await fetch(`${BASE_URI}/images/upload`, {

--- a/src/shared/components/post-form/post-content/ui/PostContent.tsx
+++ b/src/shared/components/post-form/post-content/ui/PostContent.tsx
@@ -16,15 +16,17 @@ const locale = locales['en'];
 
 type PostContentFieldEditorProps = {
   contents?: string;
+  storageId: string;
 };
 
-export const PostContent = ({ contents }: PostContentFieldEditorProps) => {
+export const PostContent = ({ contents, storageId }: PostContentFieldEditorProps) => {
   const { control } = useFormContext();
   const isMobile = useBreakpointValue({ base: true, md: false });
 
   const uploadFile = async (file: File): Promise<string> => {
     const formData = new FormData();
     formData.append('file', file);
+    formData.append('storageId', String(storageId));
 
     try {
       const response = await fetch(`${BASE_URI}/images/upload`, {

--- a/src/widgets/modals/PostModal.tsx
+++ b/src/widgets/modals/PostModal.tsx
@@ -103,6 +103,7 @@ export const PostModal = ({
     const formData = new FormData();
     formData.append('file', file);
     formData.append('storageId', String(storageId));
+    console.log('storageId', storageId); // ✅ storageId 확인
 
     try {
       setIsUploading(true);
@@ -153,6 +154,7 @@ export const PostModal = ({
       });
     } finally {
       setIsPosting(false);
+      console.log(storageId); // ✅ storageId 확인
     }
   };
 

--- a/src/widgets/modals/PostModal.tsx
+++ b/src/widgets/modals/PostModal.tsx
@@ -41,8 +41,10 @@ type PostModalProps = {
     contents: string;
     thumbnail: string;
     summary: string;
+    storageId: string;
   }) => Promise<void>;
   imageUrl?: string;
+  storageId: string;
 };
 
 type PostModalForm = {
@@ -60,6 +62,7 @@ export const PostModal = ({
   postContent,
   postSummary,
   onConfirmButton,
+  storageId,
 }: PostModalProps) => {
   const imgRef = useRef<HTMLInputElement | null>(null);
   const [isUploading, setIsUploading] = useState(false);
@@ -99,6 +102,7 @@ export const PostModal = ({
 
     const formData = new FormData();
     formData.append('file', file);
+    formData.append('storageId', String(storageId));
 
     try {
       setIsUploading(true);
@@ -145,6 +149,7 @@ export const PostModal = ({
         contents: postContent,
         thumbnail: data.thumbnail,
         summary: data.summary,
+        storageId: storageId,
       });
     } finally {
       setIsPosting(false);
@@ -181,7 +186,7 @@ export const PostModal = ({
                 <Flex bgColor='#E9ECEE' justify='center' w='full' h='166px' flexDir='column'>
                   <VStack spacing={2}>
                     {isUploading ? (
-                      <Spinner size='xl' color='customGray.500' /> // ✅ 업로드 중 스피너 표시
+                      <Spinner size='xl' color='customGray.500' />
                     ) : thumbnail ? (
                       <Image src={thumbnail} alt='thumbnail' maxW='312px' maxH='166px' />
                     ) : (


### PR DESCRIPTION
## 📝 상세 내용
> 문제 상황:

이미지(파일) 업로드 시 데이터베이스에 이미지가 쌓이게 됨 -> 근데 이 이미지를 업로드 후 프론트 단에서 백스페이스 키를 눌러서 지우더라도 db에서는 실제로 지워지지 않음 -> 파일이 너무 많이 쓰이면 용량 부족, 과금 등의 문제가 발생할 수도 있기 때문에, db에서도 지우기 위해 각 이미지마다 storageId를 할당하여 적용하기로 함.

> 해결 방법:

게시글 작성 페이지가 랜더링될 때 api 통신으로 storageId를 받아옴. 이를 변수에 저장하여 이미지 업로드 시 함께 전달하고, 게시글 저장 시에도 body에 담아 함께 전달함. 이제 게시글을 삭제하면 해당 게시글에서 업로드를 했던 모든 사진들이 함께 삭제된다. 

> postId를 사용하지 않는 이유

게시글이 저장되기 전까지는 postId가 없기 때문에 storageId라는 새로운 값을 사용함.

## #️⃣ 이슈 번호
close #91 

## 💬 리뷰 요구사항


## ⏰ 현재 버그


## 📷 스크린샷(선택)


## 🔗 참고 자료(선택)

