### PR TITLE
issue#85 채팅메세지 rest api 요청 주소 프록시로 변경

### DIFF
--- a/src/pages/chat/ui/ChatPage.tsx
+++ b/src/pages/chat/ui/ChatPage.tsx
@@ -5,28 +5,25 @@ import { Flex, Button, Text, useDisclosure } from '@chakra-ui/react';
 
 import { RouterPath } from '@shared/constants';
 import { useCustomToast } from '@shared/hooks';
+import { BASE_URI, BASE_WS_URI } from '@shared/service';
 import { authStorage } from '@shared/utils';
 
 import { ChatRoomList, ChatRoomInside, ChatUserList } from '../components';
 import { useGetChatRooms, useCreateChatRoom } from '../hooks';
 import { Client } from '@stomp/stompjs';
 
-const BASE_API_URL = 'https://algo.knu-soft.site'; // REST API 기본 URL
-const BASE_WS_URL = 'ws://algo.knu-soft.site'; // WebSocket 기본 URL
-
 export const ChatPage = () => {
-  const [roomName, setRoomName] = useState(''); // 현재 접속 중인 채팅방 이름
-  const [newRoomName, setNewRoomName] = useState(''); // 새 채팅방 이름 입력 상태
+  const [roomName, setRoomName] = useState('');
+  const [newRoomName, setNewRoomName] = useState('');
   const [messages, setMessages] = useState<{ sender: string; content: string; email: string }[]>(
     [],
   ); // 메세지 <- 총 메세지(rest + 소켓)
   const [socketMessages, setSocketMessages] = useState<
     { sender: string; content: string; email: string }[]
-  >([]); // 메세지
-  const [newMessage, setNewMessage] = useState(''); // 새로 작성 중인 메시지 상태
-  const [stompClient, setStompClient] = useState<Client | null>(null); // WebSocket 연결 객체
+  >([]);
+  const [newMessage, setNewMessage] = useState('');
+  const [stompClient, setStompClient] = useState<Client | null>(null);
 
-  // 채팅방 목록 가져오기
   const [page, setPage] = useState(0);
   const size = 10;
   const sort = 'createdAt,desc';
@@ -44,8 +41,8 @@ export const ChatPage = () => {
   const { mutate: createRoom } = useCreateChatRoom();
   const customToast = useCustomToast();
 
-  const [messagePage, setMessagePage] = useState(0); // 채팅 메시지 페이지
-  const [hasMoreMessages, setHasMoreMessages] = useState(true); // 더 불러올 메시지가 있는지 여부
+  const [messagePage, setMessagePage] = useState(0);
+  const [hasMoreMessages, setHasMoreMessages] = useState(true);
 
   const [userName, setUserName] = useState(authStorage.nickName.get());
   const [email, setEmail] = useState(authStorage.email.get());
@@ -55,12 +52,11 @@ export const ChatPage = () => {
     setEmail(authStorage.email.get());
   }, []);
 
-  // 특정 채팅방의 최근 메시지 가져오기
   const fetchRecentMessages = async (roomName: string, pageNumber: number) => {
     try {
       const encodedRoomName = encodeURIComponent(roomName);
       const response = await fetch(
-        `${BASE_API_URL}/api/v1/chat/messages/${encodedRoomName}?page=${pageNumber}&size=10&sort=chatTime,asc`,
+        `${BASE_URI}/chat/messages/${encodedRoomName}?page=${pageNumber}&size=10&sort=chatTime,asc`,
       );
       if (response.ok) {
         const data = await response.json();
@@ -74,7 +70,6 @@ export const ChatPage = () => {
     }
   };
 
-  // 채팅 메시지 스크롤 이벤트 핸들러
   const handleMessageListScroll = useCallback(() => {
     if (messageListRef.current) {
       const { scrollTop } = messageListRef.current;
@@ -100,7 +95,6 @@ export const ChatPage = () => {
     }
   }, [handleMessageListScroll]);
 
-  // 메시지 페이지 변경 시 추가 메시지 불러오기
   useEffect(() => {
     if (roomName && messagePage > 0) {
       fetchRecentMessages(roomName, messagePage);
@@ -109,7 +103,7 @@ export const ChatPage = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [messagePage]);
 
-  // **새 메시지 추가 시 자동 스크롤**
+  //새 메세지 추가 시 자동 스크롤
   useEffect(() => {
     if (messagesEndRef.current) {
       messagesEndRef.current.scrollIntoView({ behavior: 'smooth' });
@@ -127,7 +121,6 @@ export const ChatPage = () => {
       toastDescription: '채팅방이 생성되었습니다.',
     });
 
-    // 🚀 채팅방 생성 후 즉시 데이터 새로고침
     setTimeout(() => refetch(), 500);
   };
 
@@ -136,31 +129,27 @@ export const ChatPage = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // WebSocket 연결 설정 및 사용자 이름 등록
   const connectToWebSocket = () => {
     if (stompClient) {
-      stompClient.deactivate(); // 기존 WebSocket 연결 종료
+      stompClient.deactivate();
     }
 
     const client = new Client({
-      brokerURL: `${BASE_WS_URL}/api/ws`,
+      brokerURL: `${BASE_WS_URI}/api/ws`,
       debug: (str) => console.log(str),
       onConnect: () => {
         console.log('WebSocket에 연결되었습니다.');
 
-        // 사용자 목록 주제 구독
         client.subscribe('/topic/users', (messageOutput) => {
           const userList = JSON.parse(messageOutput.body);
           setUsersInRooms(userList);
         });
 
-        // 방별 사용자 목록 주제 구독
         client.subscribe('/topic/room-users', (messageOutput) => {
           const roomUserList = JSON.parse(messageOutput.body);
           setRoomUserList(roomUserList);
         });
 
-        // 사용자 입장 상태 전송 (미접속 상태)
         client.publish({
           destination: '/api/app/chat/join',
           body: JSON.stringify({
@@ -175,36 +164,31 @@ export const ChatPage = () => {
     });
 
     client.activate();
-    setStompClient(client); // WebSocket 클라이언트 상태 업데이트
+    setStompClient(client);
   };
 
-  // 특정 채팅방에 연결
   const connectToChatRoom = () => {
     if (!roomName || !userName) return;
 
     if (stompClient) {
-      stompClient.deactivate(); // 기존 연결 종료
+      stompClient.deactivate();
     }
 
     const client = new Client({
-      brokerURL: `${BASE_WS_URL}/api/ws`,
+      brokerURL: `${BASE_WS_URI}/api/ws`,
       debug: (str) => console.log(str),
       onConnect: () => {
         console.log(`${roomName} 채팅방에 연결되었습니다.`);
 
-        // 채팅방 메시지 구독
         client.subscribe(`/topic/${roomName}`, (messageOutput) => {
           const message = JSON.parse(messageOutput.body);
 
-          // 메시지 본문 뒤에 공백 추가
           message.content = message.content + ' ';
 
-          // 메시지를 상태에 저장
           setSocketMessages((prevMessages) => [message, ...prevMessages]);
           setMessages((prevMessages) => [message, ...prevMessages]);
         });
 
-        // 사용자 목록 구독
         client.subscribe('/topic/users', (messageOutput) => {
           const userList = JSON.parse(messageOutput.body);
           setUsersInRooms(userList);
@@ -215,7 +199,6 @@ export const ChatPage = () => {
           setRoomUserList(roomUserList);
         });
 
-        // 사용자 입장 정보 서버에 전송
         client.publish({
           destination: '/api/app/chat/join',
           body: JSON.stringify({ userName: userName, roomName }),
@@ -230,18 +213,16 @@ export const ChatPage = () => {
     setStompClient(client);
   };
 
-  // 채팅방 이름 변경 시 메시지와 연결 초기화
   useEffect(() => {
     if (roomName) {
-      setMessagePage(0); // 메시지 페이지 초기화
-      setMessages([]); // 메시지 목록 초기화
+      setMessagePage(0);
+      setMessages([]);
       fetchRecentMessages(roomName, 0);
       connectToChatRoom();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [roomName]);
 
-  // 메시지 전송
   const handleSendMessage = () => {
     if (!stompClient || !stompClient.connected) {
       console.log('WebSocket 연결이 활성화되지 않았습니다.');

--- a/src/shared/service/config/instance.ts
+++ b/src/shared/service/config/instance.ts
@@ -6,6 +6,8 @@ const API_PREFIX = `/api/v1`;
 // export const BASE_URI = `https://algo.knu-soft.site${API_PREFIX}`;
 export const BASE_URI = `${API_PREFIX}`;
 
+export const BASE_WS_URI = `wss://algo.knu-soft.site`;
+
 export const SERVER_FILE_URI = `https://algo.knu-soft.site`;
 
 export const fetchInstance = new Http(BASE_URI, {


### PR DESCRIPTION
## 📝 상세 내용

- 채팅 페이지 소켓 송신 메세지가 바로 추가되지 않던 오류 해결을 위해서 이슈를 팠었는데, 세션에서 닉네임을 받아오지 못해서 생긴 거였고, 현재 개발 프록시 쓰는 대로 요청 주소 변경해놨을 때, rest랑 소켓 다 정상 작동하는 거 확인해뒀습니다
- 소켓 URI https 환경 따라 ws ->  wss로 바꿨고, URI는 rest api url랑 같이 instance에서 import해서 쓰도록 옮겨뒀어요

## #️⃣ 이슈 번호

- resolve #85

## 💬 리뷰 요구사항


## ⏰ 현재 버그


## 📷 스크린샷(선택)


## 🔗 참고 자료(선택)

